### PR TITLE
fix: get users by department

### DIFF
--- a/be/internal/repository/user/impl_interface.go
+++ b/be/internal/repository/user/impl_interface.go
@@ -142,6 +142,15 @@ func (r *PostgreSQLUserRepository) GetAllUserRoleEmployeeOfDepartment(department
 	return users, nil
 }
 
+func (r *PostgreSQLUserRepository) GetAllUserRoleEmployeeOfDepartmentExluding(departmentTd, userId int64) ([]*entity.Users, error) {
+	users := []*entity.Users{}
+	result := r.db.Debug().Model(entity.Users{}).Joins("join roles on roles.id = users.role_id").Where("department_id = ?", departmentTd).Where("roles.slug = ?", "employee").Where("users.id != ?", userId).Preload("Role").Preload("Department").Find(&users)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return users, nil
+}
+
 func (r *PostgreSQLUserRepository) GetAllUserRoleManagerOfDepartment(departmentTd int64) ([]*entity.Users, error) {
 	users := []*entity.Users{}
 	result := r.db.Debug().Model(entity.Users{}).Joins("join roles on roles.id = users.role_id").Where("department_id = ?", departmentTd).Where("roles.slug = ?", "assetManager").Preload("Role").Preload("Department").Find(&users)

--- a/be/internal/repository/user/interface.go
+++ b/be/internal/repository/user/interface.go
@@ -21,6 +21,7 @@ type UserRepository interface {
 	GetUserAssetManageOfDepartment(departmentId int64) (*entity.Users, error)
 	GetAllUserRoleEmployeeOfDepartment(departmentTd int64) ([]*entity.Users, error)
 	GetAllUserRoleManagerOfDepartment(departmentTd int64) ([]*entity.Users, error)
+	GetAllUserRoleEmployeeOfDepartmentExluding(departmentId, userId int64) ([]*entity.Users, error)
 	UpdateDepartment(userId int64, departmentId int64) error
 	CheckHeadDep(depId int64) error
 	CheckManagerDep(depId int64) error

--- a/be/internal/service/user/service.go
+++ b/be/internal/service/user/service.go
@@ -278,10 +278,19 @@ func (service *UserService) GetAllUserOfDepartment(userId int64, departmentId in
 		return nil, err
 	}
 	var users []*entity.Users
-	if user.Role.Slug == "admin" {
+	switch user.Role.Slug {
+	case "admin":
 		users, err = service.repo.GetAllUserRoleManagerOfDepartment(departmentId)
-	} else {
-		users, err = service.repo.GetAllUserRoleEmployeeOfDepartment(departmentId)
+	case "assetManager":
+		if *user.DepartmentId == departmentId {
+			users, err = service.repo.GetAllUserRoleEmployeeOfDepartment(departmentId)
+		} else {
+			users, err = service.repo.GetAllUserRoleManagerOfDepartment(departmentId)
+		}
+	case "employee":
+		if *user.DepartmentId == departmentId {
+			users, err = service.repo.GetAllUserRoleEmployeeOfDepartmentExluding(departmentId, userId)
+		}
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
 - If the caller is an Admin, they will receive the manager of the selected department (PG).
 - If the caller is a Manager, and selects:
    - Their own department → returns employees in that department.
    - A different department → returns the manager of that department.
 - If the caller is an Employee, it returns all other employees in the same department (excluding the caller).